### PR TITLE
Clear all parameter values from parent request

### DIFF
--- a/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
+++ b/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
@@ -178,7 +178,7 @@ public class RainbowRestWebFilter extends RainbowRestOncePerRequestFilter {
 
         HtmlResponseWrapper copy = new HtmlResponseWrapper( response );
         request.getRequestDispatcher( node.path( INCLUSION_ELEMENT_ATTRIBUTE ).textValue() )
-               .forward( new GetHttpServlerRequest( (HttpServletRequest) request ), copy );
+               .forward( new GetHttpServletRequest( (HttpServletRequest) request ), copy );
 
         return mapper.readTree( copy.getCaptureAsString() );
     }
@@ -206,16 +206,32 @@ public class RainbowRestWebFilter extends RainbowRestOncePerRequestFilter {
         }
     }
 
-    private static class GetHttpServlerRequest extends HttpServletRequestWrapper {
+    private static class GetHttpServletRequest extends HttpServletRequestWrapper {
         private static final String GET_METHOD = "GET";
 
-        public GetHttpServlerRequest( HttpServletRequest request ) {
+        public GetHttpServletRequest( HttpServletRequest request ) {
             super( request );
         }
 
         @Override
         public String getMethod() {
             return GET_METHOD;
+        }
+
+        public String getParameter(String name) {
+            return null;
+        }
+
+        public Map<String, String[]> getParameterMap() {
+            return new TreeMap<>();
+        }
+
+        public Enumeration<String> getParameterNames() {
+            return Collections.emptyEnumeration();
+        }
+
+        public String[] getParameterValues(String name) {
+            return null;
         }
     }
 }


### PR DESCRIPTION
There is a problem when request parameters have equal names: then parameter from parent request joins with parameter for "include" request. 
For example:
```java
class DummyModel {
   public String filter;
   public Link link;
   public DummyModel(String filter) {
      this.filter = filter;
      this.link = new Link();
   }
}

class Link {
    public String href = "/second?filter=secondfilter";
    public String rel = "subelement";
}

@RequestMapping("/first")
public DummyModel first(@RequestParam String filter) {
    return new DummyModel(filter);
}

@RequestMapping("/second" )
public DummyModel second(@RequestParam String filter) {
    return new DummyModel(filter);
}
```
If you call `http://localhost:8080/first?filter=firstfilter&include=link` then in the second controller filter would be equals to `secondfilter,firstfilter` due to equal names.

So the decision was to clear parameters.