### PR TITLE
use straight braces instead of curly for include request params

### DIFF
--- a/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
+++ b/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
@@ -29,7 +29,7 @@ public class RainbowRestWebFilter extends RainbowRestOncePerRequestFilter {
     private static final String DEFAULT_INCLUDE_PARAM_NAME = "include";
     private static final String INCLUSION_ELEMENT_ATTRIBUTE = "href";
     private static final String EXCLUDE_FIELDS_INIT_SYMBOL = "-";
-    private static final Pattern INCLUDES_PATTERN = Pattern.compile( "([^,{}]+)(\\{(.+?)})*", Pattern.CASE_INSENSITIVE);
+    private static final Pattern INCLUDES_PATTERN = Pattern.compile( "([^,()]+)(\\((.+?)\\))*", Pattern.CASE_INSENSITIVE);
     private static final Comparator<Include> INCLUDE_PARTS_COMPARATOR = Comparator.comparing( Include::getIncludeFieldName );
 
     private String fieldsParamName = DEFAULT_FIELDS_PARAM_NAME;

--- a/samples/src/test/java/ua/net/tokar/json/filters/sample/ApplicationApiCompositionTest.java
+++ b/samples/src/test/java/ua/net/tokar/json/filters/sample/ApplicationApiCompositionTest.java
@@ -91,9 +91,7 @@ public class ApplicationApiCompositionTest {
     @Test
     public void includeWithRequestParamsTest() throws Exception {
         String body = restTemplate.getForObject(
-                getURIForRestTemplate(
-                        "/groups?include=users{offset:1,limit:2},users.friends{offset:2,limit:1}"
-                ),
+                "/groups?include=users(offset:1,limit:2),users.friends(offset:2,limit:1)",
                 String.class
         );
 
@@ -109,7 +107,4 @@ public class ApplicationApiCompositionTest {
 
     }
 
-    private URI getURIForRestTemplate( String url ) {
-        return URI.create( url.replaceAll( "\\{", "%7B" ).replaceAll( "}", "%7D" ) );
-    }
 }


### PR DESCRIPTION
According to RFC1738 https://tools.ietf.org/html/rfc1738 curly braces not allowed in urls. The only available braces to use in url are straight.