### PR TITLE
add removing Content-Length from headers. 

### DIFF
--- a/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestOncePerRequestFilter.java
+++ b/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestOncePerRequestFilter.java
@@ -24,6 +24,7 @@ abstract class RainbowRestOncePerRequestFilter implements Filter {
     private static final int DEFAULT_EXECUTION_TIMEOUT_SECONDS = 10;
     private static final String ALREADY_FILTERED_SUFFIX = ".FILTERED";
     private static final String DEFAULT_EXECUTION_TIMEOUT_SECONDS_PARAM_NAME = "executionTimeoutSeconds";
+    private static final String CONTENT_LENGTH_HEADER_NAME = "Content-Length";
 
     private ExecutorService executorService;
     private int executionTimeoutSeconds;
@@ -153,7 +154,7 @@ abstract class RainbowRestOncePerRequestFilter implements Filter {
         List<HttpHeader> headers = new ArrayList<>();
         for ( Enumeration<String> e = request.getHeaderNames(); e.hasMoreElements(); ) {
             String name = e.nextElement();
-            if ( "Content-Length".equalsIgnoreCase( name ) ) {
+            if ( CONTENT_LENGTH_HEADER_NAME.equalsIgnoreCase( name ) ) {
                 continue;
             }
             headers.add( new HttpHeader( name, request.getHeader( name ) ) );

--- a/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestOncePerRequestFilter.java
+++ b/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestOncePerRequestFilter.java
@@ -153,6 +153,9 @@ abstract class RainbowRestOncePerRequestFilter implements Filter {
         List<HttpHeader> headers = new ArrayList<>();
         for ( Enumeration<String> e = request.getHeaderNames(); e.hasMoreElements(); ) {
             String name = e.nextElement();
+            if ( "Content-Length".equalsIgnoreCase( name ) ) {
+                continue;
+            }
             headers.add( new HttpHeader( name, request.getHeader( name ) ) );
         }
         return headers;


### PR DESCRIPTION
HTTP GET requests works bad with Content-Length Header. When HTTP PUT/POST requests with include are processed by rainbow it is added all headers from base requests. Usually HTTP PUT/POST requests have Content-Length header

@alexeytokar @rasmus93 