### PR TITLE
If response has no content to bind, then readTree() returns null. It is needed to check that tree is not null.

### DIFF
--- a/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
+++ b/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
@@ -149,6 +149,9 @@ public class RainbowRestWebFilter extends RainbowRestOncePerRequestFilter {
 
         String content = capturingResponseWrapper.getCaptureAsString();
         JsonNode tree = mapper.readTree( content );
+        if ( tree == null ) {
+            return;
+        }
         if ( !include.isEmpty() ) {
             processIncludes( tree, include, request );
         }


### PR DESCRIPTION
@alexeytokar @rasmus93 