### PR TITLE
Fix a hang while processing invalid include of a regular array

### DIFF
--- a/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
+++ b/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
@@ -216,8 +216,9 @@ public class RainbowRestWebFilter extends RainbowRestOncePerRequestFilter {
             if ( node.isArray() ) {
                 List<Callable<JsonNode>> callables = new ArrayList<>();
                 for ( final Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
+                    JsonNode element = it.next();
                     callables.add( () -> createNodeForInclude(
-                            it.next(),
+                            element,
                             request,
                             requestParamsFromInclude
                     ) );

--- a/samples/src/main/java/ua/net/tokar/json/filters/sample/GroupsController.java
+++ b/samples/src/main/java/ua/net/tokar/json/filters/sample/GroupsController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -34,6 +35,18 @@ public class GroupsController {
                      .skip( offset )
                      .limit( limit )
                      .collect( Collectors.toList() );
+    }
+
+    @RequestMapping( "/users" )
+    public HashMap<String, List<User>> getUsers() {
+        HashMap<String, List<User>> userWrapper = new HashMap<>();
+        List<User> users = Arrays.asList(
+                new User( "boss", new Link( "/users/1/friends", "friends" ) ),
+                new User( "cat", new Link( "/users/2/friends", "friends" ) ),
+                new User( "dog", new Link( "/users/42/friends", "friends" ) )
+        );
+        userWrapper.put( "users", users );
+        return userWrapper;
     }
 
     @RequestMapping( "/users/{id}/friends" )


### PR DESCRIPTION
Before this patch, response that looks like this:

```json
{
  "array": [
    { "link": { "href": "/link/1" } },
    { "link": { "href": "/link/2" } },
    { "link": { "href": "/link/3" } }
  ]
}
```

with a parameter `include=array` (instead of `include=array.link`) would
cause an indefinite hang while RanbowRest tries to create as many
`Callable`s as it possibly can.