### PR TITLE
Use UTF-8 for captured responses if charset is not set explicitly

### DIFF
--- a/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestBatchFilter.java
+++ b/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestBatchFilter.java
@@ -123,11 +123,10 @@ public class RainbowRestBatchFilter extends RainbowRestOncePerRequestFilter {
                 return;
             }
             response.setContentType( "application/json" );
-            response.getWriter().write(
-                    getBatchResults(
-                            map,
-                            (HttpServletRequest) request
-                    ).toString() );
+            mapper.writeValue(
+                    response.getOutputStream(),
+                    getBatchResults( map, (HttpServletRequest) request )
+            );
         }
     }
 

--- a/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestOncePerRequestFilter.java
+++ b/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestOncePerRequestFilter.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -109,7 +110,7 @@ abstract class RainbowRestOncePerRequestFilter implements Filter {
             ServletRequest request,
             ServletResponse response
     ) throws ServletException, IOException {
-        HtmlResponseWrapper responseWrapper = new HtmlResponseWrapper( response );
+        JsonResponseWrapper responseWrapper = new JsonResponseWrapper( response );
         request.getRequestDispatcher( relativeUrl )
                .forward(
                        new GetHttpServletRequest( (HttpServletRequest) request ),
@@ -138,7 +139,7 @@ abstract class RainbowRestOncePerRequestFilter implements Filter {
         List<NameValuePair> params = new ArrayList<>();
         params.addAll( URLEncodedUtils.parse(
                 new URI( relativeUrl ),
-                Charset.forName( "UTF-8" )
+                StandardCharsets.UTF_8
         ) );
         params.addAll( additionalRequestParams );
 

--- a/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
+++ b/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilter.java
@@ -124,7 +124,7 @@ public class RainbowRestWebFilter extends RainbowRestOncePerRequestFilter {
             return;
         }
 
-        HtmlResponseWrapper capturingResponseWrapper = new HtmlResponseWrapper( response );
+        JsonResponseWrapper capturingResponseWrapper = new JsonResponseWrapper( response );
         filterChain.doFilter( request, capturingResponseWrapper );
 
         Set<String> includeFields = new HashSet<>();
@@ -159,7 +159,7 @@ public class RainbowRestWebFilter extends RainbowRestOncePerRequestFilter {
             filterTree( tree, includeFields, excludeFields );
         }
 
-        response.getWriter().write( tree.toString() );
+        mapper.writeValue(response.getOutputStream(), tree);
     }
 
     private void processIncludes(


### PR DESCRIPTION
In the newest versions of Spring Framework, after a [change][1] to align
it with the [RFC8259][2], the character encoding is no longer set to
UTF-8 for responses with `application/json` content-type.

This fix makes a `JsonResponseWrapper` use UTF-8 by default, instead of
getting charset from the wrapped `Response` instance which could have
been not set and so it returns default ISO-8895-1.

[1]: https://github.com/spring-projects/spring-framework/issues/22788
[2]: https://tools.ietf.org/html/rfc8259#section-11