### PR TITLE
Adds a constructor with the explicit server URI.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
         maven { url 'https://repo.spring.io/plugins-release' }
     }

--- a/filters/build.gradle
+++ b/filters/build.gradle
@@ -5,5 +5,14 @@ dependencies {
             'org.apache.httpcomponents:httpclient:4.5.3',
             'org.apache.commons:commons-lang3:3.4',
             'org.slf4j:slf4j-api:1.7.25'
+
+    testImplementation('org.springframework.boot:spring-boot-starter-test:2.2.2.RELEASE') {
+        exclude module: 'mockito-junit-jupiter'
+        exclude module: 'slf4j-api'
+    }
+}
+
+test {
+    useJUnitPlatform()
 }
 

--- a/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestBatchFilter.java
+++ b/filters/src/main/java/ua/net/tokar/json/rainbowrest/RainbowRestBatchFilter.java
@@ -12,6 +12,7 @@ import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
@@ -32,7 +33,7 @@ public class RainbowRestBatchFilter extends RainbowRestOncePerRequestFilter {
     private String batchEndpointUri = DEFAULT_BATCH_ENDPOINT_URI;
     private Integer maxBatchSize;
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
 
     public RainbowRestBatchFilter() {
@@ -70,6 +71,19 @@ public class RainbowRestBatchFilter extends RainbowRestOncePerRequestFilter {
             Integer maxBatchSize
     ) {
         super( executorService, executionTimeoutSeconds, httpClient );
+        this.batchEndpointUri = batchEndpointUri;
+        this.maxBatchSize = maxBatchSize;
+    }
+
+    public RainbowRestBatchFilter(
+            ExecutorService executorService,
+            int executionTimeoutSeconds,
+            HttpClient httpClient,
+            String batchEndpointUri,
+            Integer maxBatchSize,
+            URI batchServerUri
+    ) {
+        super( executorService, executionTimeoutSeconds, httpClient, batchServerUri );
         this.batchEndpointUri = batchEndpointUri;
         this.maxBatchSize = maxBatchSize;
     }
@@ -143,11 +157,7 @@ public class RainbowRestBatchFilter extends RainbowRestOncePerRequestFilter {
                        try {
                            jsonNode = mapper.readTree(
                                    getResponseViaInternalDispatching(
-                                           buildUri(
-                                                   request,
-                                                   relativeUrl,
-                                                   Collections.emptyList()
-                                           ),
+                                           getUri( request, relativeUrl, Collections.emptyList() ),
                                            headers
                                    )
                            );

--- a/filters/src/test/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilterUnitTest.java
+++ b/filters/src/test/java/ua/net/tokar/json/rainbowrest/RainbowRestWebFilterUnitTest.java
@@ -1,0 +1,52 @@
+package ua.net.tokar.json.rainbowrest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+
+import static org.mockito.Mockito.verify;
+
+class RainbowRestWebFilterUnitTest {
+
+    public static final String RELATIVE_URL = "/awesome-endpoint";
+    public static final String BATCH_SERVER_URI = "https://batch.server.org";
+
+    @Mock ExecutorService executorService;
+    @Mock HttpServletRequest request;
+    @Mock HttpClient httpClient;
+
+    URI batchServerUri = new URI( BATCH_SERVER_URI );
+    @Spy RainbowRestWebFilter rainbowRestWebFilter = new RainbowRestWebFilter(
+            executorService,
+            10,
+            httpClient,
+            "",
+            "",
+            batchServerUri
+    );
+
+    RainbowRestWebFilterUnitTest() throws URISyntaxException {
+    }
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks( this );
+    }
+
+    @Test
+    void getUriMustUseExplicitBatchServerPathIfItExists() throws URISyntaxException {
+        // Setup
+        // Run
+        rainbowRestWebFilter.getUri( request, RELATIVE_URL, Collections.emptyList() );
+        // Assert
+        verify( rainbowRestWebFilter ).buildUri( batchServerUri, RELATIVE_URL, Collections.emptyList() );
+    }
+}


### PR DESCRIPTION
The new constructor allows forcing RainbowRestBatchFilter to use a predefined target server URI instead of reconstructing it from the request. It allows, for example, to make further HTTP batch requests when the initial request with the 'include' param was with the HTTPS scheme.